### PR TITLE
fixed background image height getting cropped incorrectly

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,14 +8,15 @@
     "postinstall": "./node_modules/.bin/bower install",
     "test": "./node_modules/.bin/karma start karma.conf.js",
     "build": "gulp build && cd .. && rm -rf folderPlugin_release.zip && zip -r folderPlugin_release.zip folderPlugin_release/",
-    "preinstall": "npx install npm-force-resolutions"
+    "preinstall": "npm install --package-lock-only --ignore-scripts && npx npm-force-resolutions"
   },
   "resolutions": {
     "graceful-fs": "4.2.3"
   },
   "dependencies": {
     "bower": "^1.5.3",
-    "karma-cli": "^0.1.0"
+    "karma-cli": "^0.1.0",
+    "npm-force-resolutions": "0.0.10"
   },
   "repository": {
     "type": "git",

--- a/test/assets/buildfire.js
+++ b/test/assets/buildfire.js
@@ -793,7 +793,7 @@ var buildfire = {
                 throw ("options not an object");
 
             if (options.width == 'full') options.width = window.innerWidth;
-            if (options.height == 'full') options.height = window.innerHeight;
+            if (options.height == 'full') options.height = document.documentElement.clientHeight;
 
             if (options.width && !options.height)
                 return root + "width/" + (options.width * ratio) + "/" + url;

--- a/widget/index.html
+++ b/widget/index.html
@@ -3,6 +3,7 @@
 <head lang="en">
     <meta name="buildfire" content="disableBootstrap,disableAppStyles"/>
     <script src="../../../scripts/_bundles/buildfire_lightcarousel.min.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!--this css is important to be loaded first for the first paint-->
     <style>
         .item-disabled {
@@ -173,7 +174,7 @@
                 _elementHeight = element.parentElement.parentElement.clientHeight;
             }
 
-            var wT = window.pageYOffset, wB = wT + window.innerHeight + (_elementHeight * 3), cRect, pT, pB, p = 0;
+            var wT = window.pageYOffset, wB = wT + document.documentElement.clientHeight + (_elementHeight * 3), cRect, pT, pB, p = 0;
             cRect = element.getBoundingClientRect();
             pT = wT + cRect.top;
             pB = pT + cRect.height;
@@ -569,10 +570,12 @@
         }
 
         if (bgImage) {
-            style.innerHTML += "#light-folder-body{ background: no-repeat url('" + buildfire.imageLib.cropImage(bgImage, {
+            let url = buildfire.imageLib.cropImage(bgImage, {
                     width: window.innerWidth,
-                    height: window.innerHeight
-                }).replace(/'/g,"%27") + "') !Important; background-size: cover !important; } ";
+                    height: document.documentElement.clientHeight
+                });
+            url = url.replace(/'/g,"%27");
+            style.innerHTML += "#light-folder-body{ background: no-repeat url('" + url + "') !Important; background-size: cover !important; } ";
             // enable for imageCache
             // style.innerHTML += "body { background-size: cover !important; } ";
             // buildfire.imageLib.cropImage(bgImage, { width: window.innerWidth, height: window.innerHeight }, document.body);


### PR DESCRIPTION
JIRA ticket: https://buildfire.atlassian.net/browse/PT-3695
Reason for changing window.innerHeight to document.documentElement.clientHeight is that window innerHeight can sometimes cause some unexpected problems on iOS devices, also added the meta viewport tag just to make sure height is always correct